### PR TITLE
Convert to plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ For example; Array of text, plain text, etc.
 Content:
 
 - [Installation](#installation)
+- [Basic Usage](#basic-usage)
 - [Convert to Array](#convert-to-array)
 - [Convert to Plain Text](#convert-to-plain-text)
   - [Options](#special-options)
-- [Options](#options)
+- [Global Options](#global-options)
 
-## Installation
+# Installation
 
 ```bash
 # npm
@@ -27,9 +28,7 @@ npm install --save convert-draftjs
 yarn add convert-draftjs
 ```
 
-## Convert to Array
-
-Easily convert the result or the current state of DraftJS into an array of text.
+# Basic Usage
 
 #### Convert editor state directly
 
@@ -50,14 +49,27 @@ import { convertDraftToArray } from 'convert-draftjs';
 // from database (JSON or string)
 const mockDataFromDatabase =
   '{"blocks":[{"key":"5aeg1","text":"TEST","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]}';
+
 const result: string[] = convertDraftToArray(mockDataFromDatabase);
 
 // ["TEST"]
 ```
 
-## Convert to Plain Text
+# Convert to Array
 
-Easily convert the result or the current state of DraftJS into plain strings with characters count.
+Easily convert the result or the current state of DraftJS into an array of text.
+
+```typescript
+import { convertDraftToArray } from 'convert-draftjs';
+
+const result: string[] = convertDraftToArray(draftResult);
+
+// ["Hello", "World"]
+```
+
+# Convert to Plain Text
+
+Easily convert the result or the current state of DraftJS into plain strings.
 
 ```ts
 import { convertDraftToArray } from 'convert-draftjs';
@@ -67,13 +79,12 @@ convertDraftToPlain(draftjsResult);
 // result
 {
   result: 'Hello World',
-  chars: 3,
 }
 ```
 
 ### Special Options
 
-`Join: string | undefined`
+`join: string | undefined`
 
 Default: ' '
 
@@ -87,7 +98,28 @@ convertDraftToPlain(draftjsResult, {
 // result
 {
   result: 'Hello.World',
-  chars: 3,
+}
+```
+
+<hr />
+
+`includeCounter: boolean`
+
+Default: false
+
+Do you want to include char and word counter?
+if true it will return result with sum of chars and words. This is very useful for example when you want to determine reading time for each content.
+
+```ts
+convertDraftToPlain(draftjsResult, {
+  includeCounter: true,
+});
+
+// result
+{
+  result: 'Hello World',
+  chars: 11,
+  words: 2,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Content:
 
 - [Installation](#installation)
 - [Convert to Array](#convert-to-array)
+- [Convert to Plain Text](#convert-to-plain-text)
+  - [Options](#special-options)
 - [Options](#options)
 
 ## Installation
@@ -37,7 +39,7 @@ import { convertDraftToArray } from 'convert-draftjs';
 // from draftjs raw content state
 const result: string[] = convertDraftToArray(editorState.getCurrentContent());
 
-console.log(result); // ["Hello", "World", ...]
+// ["Hello", "World", ...]
 ```
 
 #### Convert from the database (usually stringified json)
@@ -50,10 +52,46 @@ const mockDataFromDatabase =
   '{"blocks":[{"key":"5aeg1","text":"TEST","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}]}';
 const result: string[] = convertDraftToArray(mockDataFromDatabase);
 
-console.log(result); // ["TEST"]
+// ["TEST"]
 ```
 
-## Options
+## Convert to Plain Text
+
+Easily convert the result or the current state of DraftJS into plain strings with characters count.
+
+```ts
+import { convertDraftToArray } from 'convert-draftjs';
+
+convertDraftToPlain(draftjsResult);
+
+// result
+{
+  result: 'Hello World',
+  chars: 3,
+}
+```
+
+### Special Options
+
+`Join: string | undefined`
+
+Default: ' '
+
+Set this options to anything to set join element between blocks. For example:
+
+```ts
+convertDraftToPlain(draftjsResult, {
+  join: '.',
+});
+
+// result
+{
+  result: 'Hello.World',
+  chars: 3,
+}
+```
+
+## Global Options
 
 #### select: [ 'all' | 'header-one' | 'unstyled' | 'code-block' ]
 
@@ -67,7 +105,7 @@ const codeBlock: string[] = convertDraftToArray(data, {
   select: ['code-block'],
 });
 
-console.log(codeBlock); // ["console.log();", "alert();", ...]
+// ["console.log();", "alert();", ...]
 ```
 
 #### includeBlank: boolean
@@ -81,5 +119,5 @@ const codeBlock: string[] = convertDraftToArray(data, {
   includeBlank: true,
 });
 
-console.log(codeBlock); // ["Hello", "", "World", "", ...]
+// ["Hello", "", "World", "", ...]
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import convertDraftToArray from './lib/convertDraftToArray';
 import parseDraftResult from './lib/parseDraftResult';
+import convertDraftToArray from './lib/convertDraftToArray';
+import convertDraftToPlain from './lib/convertDraftToPlain';
 
-export { convertDraftToArray, parseDraftResult };
+export { convertDraftToArray, parseDraftResult, convertDraftToPlain };

--- a/src/lib/convertDraftToPlain.ts
+++ b/src/lib/convertDraftToPlain.ts
@@ -1,0 +1,32 @@
+import { ParsedJson } from '../types/parsedjson';
+import { Options } from '../types/options';
+import { convertDraftToArray } from '..';
+
+interface ConvertToPlainOptions extends Options {
+  /**
+   * Join element of every blocks
+   * for example set join to ','
+   * will have result "Hello,World"
+   *
+   * default: space or ' '
+   */
+  join?: string | undefined;
+}
+
+/**
+ * @param draftResult (JSON or Strings)
+ * @param options
+ * @returns plain string and sums of characters
+ */
+export default function convertDraftToPlain(
+  draftResult: ParsedJson | string,
+  options?: ConvertToPlainOptions
+): { result: string; chars: number } {
+  const joinElement: string = options?.join ?? ' ';
+
+  const result: string = convertDraftToArray(draftResult, options).join(
+    joinElement
+  );
+  const counter: number = result.length;
+  return { result: result, chars: counter };
+}

--- a/src/lib/convertDraftToPlain.ts
+++ b/src/lib/convertDraftToPlain.ts
@@ -1,32 +1,39 @@
 import { ParsedJson } from '../types/parsedjson';
-import { Options } from '../types/options';
 import { convertDraftToArray } from '..';
-
-interface ConvertToPlainOptions extends Options {
-  /**
-   * Join element of every blocks
-   * for example set join to ','
-   * will have result "Hello,World"
-   *
-   * default: space or ' '
-   */
-  join?: string | undefined;
-}
+import { ConvertToPlainOptions } from '../types/options';
+import { ConvertToPlainReturnType } from '../types/return';
 
 /**
  * @param draftResult (JSON or Strings)
  * @param options
- * @returns plain string and sums of characters
  */
 export default function convertDraftToPlain(
   draftResult: ParsedJson | string,
   options?: ConvertToPlainOptions
-): { result: string; chars: number } {
+): ConvertToPlainReturnType {
   const joinElement: string = options?.join ?? ' ';
+  /**
+   * Do you want to include char and word counter?
+   * if true it will return result with sum of chars and words.
+   * @default ' '
+   */
+  const isIncludeCounter: boolean = options?.includeCounter ?? false;
 
   const result: string = convertDraftToArray(draftResult, options).join(
     joinElement
   );
-  const counter: number = result.length;
-  return { result: result, chars: counter };
+
+  if (isIncludeCounter) {
+    const chars: number = result.length;
+    const words: number =
+      joinElement.length > 0
+        ? result.split(joinElement).filter(function(n) {
+            return n != joinElement;
+          }).length
+        : 1;
+
+    return { result: result, chars: chars, words: words };
+  }
+
+  return { result: result };
 }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -18,3 +18,19 @@ export interface Options {
    */
   includeBlank?: boolean;
 }
+
+export interface ConvertToPlainOptions extends Options {
+  /**
+   * Join element of every blocks
+   * for example set join to ','
+   * will have result "Hello,World"
+   *
+   * default: space or ' '
+   */
+  join?: string | undefined;
+  /**
+   * Do you want to include char and word counter?
+   * if true it will return result with sum of chars and words.
+   */
+  includeCounter?: boolean;
+}

--- a/src/types/return.ts
+++ b/src/types/return.ts
@@ -1,0 +1,5 @@
+export interface ConvertToPlainReturnType {
+  result: string;
+  chars?: number;
+  words?: number;
+}

--- a/test/convertToPlain.test.ts
+++ b/test/convertToPlain.test.ts
@@ -1,0 +1,27 @@
+import { convertDraftToPlain } from '../src/index';
+import { rawData } from './mocks/data';
+
+describe('convertToPlain', () => {
+  it('The function should return string result and sums of chars', () => {
+    const expectedResult = { chars: 26, result: 'TEST A B C alert("Test!");' };
+    expect(convertDraftToPlain(rawData)).toEqual(expectedResult);
+  });
+
+  it('The function should return string result separated by comma', () => {
+    const expectedResult = { chars: 26, result: 'TEST,A,B,C,alert("Test!");' };
+    expect(
+      convertDraftToPlain(rawData, {
+        join: ',',
+      })
+    ).toEqual(expectedResult);
+  });
+
+  it('The function should return string result with no separated', () => {
+    const expectedResult = { chars: 22, result: 'TESTABCalert("Test!");' };
+    expect(
+      convertDraftToPlain(rawData, {
+        join: '',
+      })
+    ).toEqual(expectedResult);
+  });
+});

--- a/test/convertToPlain.test.ts
+++ b/test/convertToPlain.test.ts
@@ -2,13 +2,13 @@ import { convertDraftToPlain } from '../src/index';
 import { rawData } from './mocks/data';
 
 describe('convertToPlain', () => {
-  it('The function should return string result and sums of chars', () => {
-    const expectedResult = { chars: 26, result: 'TEST A B C alert("Test!");' };
+  it('The function should return string result', () => {
+    const expectedResult = { result: 'TEST A B C alert("Test!");' };
     expect(convertDraftToPlain(rawData)).toEqual(expectedResult);
   });
 
   it('The function should return string result separated by comma', () => {
-    const expectedResult = { chars: 26, result: 'TEST,A,B,C,alert("Test!");' };
+    const expectedResult = { result: 'TEST,A,B,C,alert("Test!");' };
     expect(
       convertDraftToPlain(rawData, {
         join: ',',
@@ -17,10 +17,37 @@ describe('convertToPlain', () => {
   });
 
   it('The function should return string result with no separated', () => {
-    const expectedResult = { chars: 22, result: 'TESTABCalert("Test!");' };
+    const expectedResult = { result: 'TESTABCalert("Test!");' };
     expect(
       convertDraftToPlain(rawData, {
         join: '',
+      })
+    ).toEqual(expectedResult);
+  });
+
+  it('The function should return string result with char and word counter', () => {
+    const expectedResult = {
+      result: 'TEST A B C alert("Test!");',
+      chars: 26,
+      words: 5,
+    };
+    expect(
+      convertDraftToPlain(rawData, {
+        includeCounter: true,
+      })
+    ).toEqual(expectedResult);
+  });
+
+  it('The function should return string result with char and word counter even with join option', () => {
+    const expectedResult = {
+      result: 'TEST-A-B-C-alert("Test!");',
+      chars: 26,
+      words: 5,
+    };
+    expect(
+      convertDraftToPlain(rawData, {
+        includeCounter: true,
+        join: '-',
       })
     ).toEqual(expectedResult);
   });


### PR DESCRIPTION
Convert draftjs result to plain text with characters count
Docs already changed. See [Docs](https://github.com/resqiar/convert-draftjs/blob/convert-to-plain/README.md)